### PR TITLE
chore: add helper script that merge compile_commands.json

### DIFF
--- a/controlunit/helpers/README.md
+++ b/controlunit/helpers/README.md
@@ -1,0 +1,15 @@
+# helpers/
+
+Utility scripts for development.
+
+## merge_compile_commands.py
+
+This script merges `compile_commands.json` from the main project (`build/`) and the test project (`test_runner/build/`) into a single file used by VSCode for IntelliSense.
+
+### How to run
+
+From the project root:
+
+```bash
+python3 helpers/merge_compile_commands.py
+```

--- a/controlunit/helpers/merge_compile_commands.py
+++ b/controlunit/helpers/merge_compile_commands.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+import json
+
+repo_root = Path(__file__).parent.parent
+build_dir = repo_root / "build"
+
+root_cc = build_dir / "compile_commands.json"
+test_cc = repo_root / "test_runner" / "build" / "compile_commands.json"
+
+if not test_cc.exists():
+    print("No test_runner/build/compile_commands.json found")
+    exit(0)
+
+with root_cc.open() as f1, test_cc.open() as f2:
+    merged = json.load(f1) + json.load(f2)
+
+with root_cc.open("w") as out:
+    json.dump(merged, out, indent=2)
+
+print(f"Merged main and test_runner compile_commands.json to {root_cc}")


### PR DESCRIPTION
Added helper script that merge compile_commands.json from /build and test_runner/build

VSCode don't automatically find ESP-IDF test files since test_runner is a "separate project" 

With this script Intellisense does it's job
