### PR TITLE
Feature 17 7114 setup linting rules for embedded repo

### DIFF
--- a/controlunit/.clang-format
+++ b/controlunit/.clang-format
@@ -1,0 +1,43 @@
+BasedOnStyle: LLVM
+Language: Cpp
+Standard: Latest
+
+IndentWidth: 4
+TabWidth: 4
+UseTab: Never
+
+ColumnLimit: 100
+AllowShortFunctionsOnASingleLine: Inline
+BreakBeforeBraces: Attach
+BraceWrapping:
+  AfterFunction: false
+  AfterControlStatement: false
+  AfterEnum: false
+  AfterStruct: false
+
+SortIncludes: true
+IncludeBlocks: Preserve
+IncludeCategories:
+  - Regex: '^".*\.h"'
+    Priority: 1
+  - Regex: '^<.*\.h>'
+    Priority: 2
+  - Regex: '.*'
+    Priority: 3
+
+PointerAlignment: Left
+ReferenceAlignment: Left
+
+SpacesBeforeTrailingComments: 1
+SpaceBeforeParens: ControlStatements
+SpaceAfterCStyleCast: true
+
+AlignConsecutiveAssignments: true
+AlignConsecutiveDeclarations: true
+AlignOperands: true
+AlignTrailingComments: true
+
+Cpp11BracedListStyle: true
+AllowAllParametersOfDeclarationOnNextLine: false
+BinPackParameters: false
+BinPackArguments: false

--- a/controlunit/.clang-tidy
+++ b/controlunit/.clang-tidy
@@ -11,18 +11,26 @@ Checks: >
   -hicpp-*,
   -llvm-header-guard,
   -modernize-use-trailing-return-type
+  -misc-include-cleaner
+  -clang-diagnostic-error
 
 CheckOptions:
   - key: modernize-use-auto.MinTypeNameLength
     value: '15'
   - key: readability-identifier-naming.FunctionCase
-    value: camelCase
+    value: camelBack
   - key: readability-identifier-naming.VariableCase
     value: camelBack
   - key: readability-identifier-naming.ConstantPrefix
     value: k
-  - key: readability-identifier-naming.MemberPrefix
+  - key: readability-identifier-naming.PrivateMemberPrefix
     value: m_
+  - key: readability-identifier-naming.PrivateMemberCase
+    value: camelBack
+  - key: readability-identifier-naming.ProtectedMemberPrefix
+    value: m_
+  - key: readability-identifier-naming.ProtectedMemberCase
+    value: camelBack
   - key: readability-identifier-naming.ClassCase
     value: CamelCase
   - key: readability-identifier-naming.StructCase

--- a/controlunit/.clang-tidy
+++ b/controlunit/.clang-tidy
@@ -1,0 +1,43 @@
+Checks: >
+  clang-analyzer-*,
+  bugprone-*,
+  performance-*,
+  readability-*,
+  cppcoreguidelines-*,
+  modernize-*,
+  misc-*,
+  -fuchsia-*,
+  -google-*,
+  -hicpp-*,
+  -llvm-header-guard,
+  -modernize-use-trailing-return-type
+
+CheckOptions:
+  - key: modernize-use-auto.MinTypeNameLength
+    value: '15'
+  - key: readability-identifier-naming.FunctionCase
+    value: camelCase
+  - key: readability-identifier-naming.VariableCase
+    value: camelBack
+  - key: readability-identifier-naming.ConstantPrefix
+    value: k
+  - key: readability-identifier-naming.MemberPrefix
+    value: m_
+  - key: readability-identifier-naming.ClassCase
+    value: CamelCase
+  - key: readability-identifier-naming.StructCase
+    value: CamelCase
+  - key: readability-identifier-naming.EnumCase
+    value: CamelCase
+  - key: readability-identifier-naming.EnumConstantCase
+    value: CamelCase
+  - key: readability-identifier-naming.NamespaceCase
+    value: lower_case
+  - key: readability-identifier-naming.GlobalConstantPrefix
+    value: k
+  - key: readability-identifier-naming.GlobalConstantCase
+    value: CamelCase
+  - key: cppcoreguidelines-pro-type-vararg.IgnoreMacros
+    value: 'ESP_LOGI,ESP_LOGE,ESP_LOGW,ESP_LOGD,UNITY_BEGIN,UNITY_END,RUN_TEST,TEST_ASSERT_EQUAL'
+  - key: misc-definitions-in-headers.IgnoreMacros
+    value: 'ESP_EVENT_HANDLER_INSTANCE_DECLARE'

--- a/controlunit/components/net_utils/wifi_manager.cpp
+++ b/controlunit/components/net_utils/wifi_manager.cpp
@@ -2,8 +2,8 @@
 
 static const char* WIFI_TAG = "wifi_setup";
 
-static void wifi_event_handler(void* arg, esp_event_base_t event_base,
-                               int32_t event_id, void* event_data) {
+static void
+wifi_event_handler(void* arg, esp_event_base_t event_base, int32_t event_id, void* event_data) {
     ESP_LOGI(WIFI_TAG, "wifi_event_handler triggered: base=%s, id=%d", event_base, event_id);
     if (event_base == IP_EVENT && event_id == IP_EVENT_STA_GOT_IP) {
         ip_event_got_ip_t* event = (ip_event_got_ip_t*) event_data;
@@ -12,8 +12,8 @@ static void wifi_event_handler(void* arg, esp_event_base_t event_base,
         ESP_LOGI(WIFI_TAG, "Netmask: " IPSTR, IP2STR(&event->ip_info.netmask));
     }
     if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_DISCONNECTED) {
-    ESP_LOGW(WIFI_TAG, "Disconnected from Wi-Fi, retrying...");
-    esp_wifi_connect();  // Optional: auto-reconnect
+        ESP_LOGW(WIFI_TAG, "Disconnected from Wi-Fi, retrying...");
+        esp_wifi_connect(); // Optional: auto-reconnect
     }
 }
 
@@ -26,27 +26,31 @@ void init_wifi() {
     ESP_ERROR_CHECK(esp_event_loop_create_default());
     esp_netif_create_default_wifi_sta();
 
-    esp_err_t err = esp_event_handler_register(IP_EVENT, IP_EVENT_STA_GOT_IP, &wifi_event_handler, NULL);
+    esp_err_t err =
+        esp_event_handler_register(IP_EVENT, IP_EVENT_STA_GOT_IP, &wifi_event_handler, NULL);
     if (err != ESP_OK) {
-      ESP_LOGE(WIFI_TAG, "Failed to register IP event handler: %s", esp_err_to_name(err));
+        ESP_LOGE(WIFI_TAG, "Failed to register IP event handler: %s", esp_err_to_name(err));
     }
 
-    esp_err_t err2 = esp_event_handler_register(WIFI_EVENT, WIFI_EVENT_STA_CONNECTED, &wifi_event_handler, NULL);
+    esp_err_t err2 =
+        esp_event_handler_register(WIFI_EVENT, WIFI_EVENT_STA_CONNECTED, &wifi_event_handler, NULL);
     if (err2 != ESP_OK) {
         ESP_LOGE(WIFI_TAG, "Failed to register Wi-Fi event handler: %s", esp_err_to_name(err2));
     }
 
-    esp_err_t err3 = esp_event_handler_register(WIFI_EVENT, WIFI_EVENT_STA_DISCONNECTED, &wifi_event_handler, NULL);
+    esp_err_t err3 = esp_event_handler_register(
+        WIFI_EVENT, WIFI_EVENT_STA_DISCONNECTED, &wifi_event_handler, NULL);
     if (err3 != ESP_OK) {
-        ESP_LOGE(WIFI_TAG, "Failed to register Wi-Fi disconnect handler: %s", esp_err_to_name(err3));
+        ESP_LOGE(
+            WIFI_TAG, "Failed to register Wi-Fi disconnect handler: %s", esp_err_to_name(err3));
     }
 
     wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
     esp_wifi_init(&cfg);
 
     wifi_config_t wifi_config = {};
-    strncpy((char*)wifi_config.sta.ssid, WIFI_SECRET_SSID, sizeof(wifi_config.sta.ssid));
-    strncpy((char*)wifi_config.sta.password, WIFI_SECRET_PASS, sizeof(wifi_config.sta.password));
+    strncpy((char*) wifi_config.sta.ssid, WIFI_SECRET_SSID, sizeof(wifi_config.sta.ssid));
+    strncpy((char*) wifi_config.sta.password, WIFI_SECRET_PASS, sizeof(wifi_config.sta.password));
 
     esp_wifi_set_mode(WIFI_MODE_STA);
     esp_wifi_set_config(WIFI_IF_STA, &wifi_config);

--- a/controlunit/components/net_utils/wifi_manager.h
+++ b/controlunit/components/net_utils/wifi_manager.h
@@ -1,10 +1,10 @@
 #pragma once
 #include "wifi_config.h"
+#include <esp_event.h>
 #include <esp_http_server.h>
 #include <esp_log.h>
-#include <esp_wifi.h>
-#include <esp_event.h>
 #include <esp_netif.h>
+#include <esp_wifi.h>
 #include <nvs_flash.h>
 
 // static void wifi_event_handler(void *arg, esp_event_base_t event_base,

--- a/controlunit/components/rest_server/handlers/hello_handler.cpp
+++ b/controlunit/components/rest_server/handlers/hello_handler.cpp
@@ -2,7 +2,7 @@
 
 static const char* TAG = "hello_handler";
 
-esp_err_t hello_get_handler(httpd_req_t *req) {
+esp_err_t hello_get_handler(httpd_req_t* req) {
     ESP_LOGI(TAG, "Handling /hello request");
     etl::string<64> resp_str = "Hello from ETL powered ESP32 rest server!";
     httpd_resp_send(req, resp_str.c_str(), resp_str.size());

--- a/controlunit/components/rest_server/handlers/hello_handler.h
+++ b/controlunit/components/rest_server/handlers/hello_handler.h
@@ -3,4 +3,4 @@
 #include "esp_log.h"
 #include <etl/string.h>
 
-esp_err_t hello_get_handler(httpd_req_t *req);
+esp_err_t hello_get_handler(httpd_req_t* req);

--- a/controlunit/components/rest_server/handlers/postexample_handler.cpp
+++ b/controlunit/components/rest_server/handlers/postexample_handler.cpp
@@ -2,12 +2,12 @@
  * @file postexample_handler.cpp
  * @author Erik Dahl (erik@iunderlandet.se)
  * @brief Example of POST handler for http server
- * 
+ *
  * Note that since the ESP-IDF use TLSF for heap allocations
  * it is safe to use std::string (as well as new/delete)
- * 
+ *
  * @date 2025-09-12
- * 
+ *
  */
 #include "postexample_handler.h"
 #include "esp_log.h"
@@ -15,18 +15,18 @@
 
 static const char* TAG = "postexample_handler";
 
-esp_err_t postexample_post_handler(httpd_req_t *req) {
+esp_err_t postexample_post_handler(httpd_req_t* req) {
     ESP_LOGI(TAG, "Handling /postexample request");
 
-    int total_len = req->content_len;
+    int         total_len = req->content_len;
     std::string body;
     body.reserve(total_len);
 
     char buf[256];
-    int remaining = total_len;
+    int  remaining = total_len;
 
     while (remaining > 0) {
-        int to_read = remaining > sizeof(buf) ? sizeof(buf) : remaining;
+        int to_read  = remaining > sizeof(buf) ? sizeof(buf) : remaining;
         int received = httpd_req_recv(req, buf, to_read);
 
         if (received <= 0) {

--- a/controlunit/components/rest_server/handlers/postexample_handler.h
+++ b/controlunit/components/rest_server/handlers/postexample_handler.h
@@ -1,4 +1,4 @@
 #pragma once
 #include "esp_http_server.h"
 
-esp_err_t postexample_post_handler(httpd_req_t *req);
+esp_err_t postexample_post_handler(httpd_req_t* req);

--- a/controlunit/components/rest_server/handlers/status_handler.cpp
+++ b/controlunit/components/rest_server/handlers/status_handler.cpp
@@ -3,7 +3,7 @@
 
 static const char* TAG = "status_handler";
 
-esp_err_t status_get_handler(httpd_req_t *req) {
+esp_err_t status_get_handler(httpd_req_t* req) {
     ESP_LOGI(TAG, "Handling /status request");
     const char* resp_str = "Status: OK";
     httpd_resp_send(req, resp_str, strlen(resp_str));

--- a/controlunit/components/rest_server/handlers/status_handler.h
+++ b/controlunit/components/rest_server/handlers/status_handler.h
@@ -1,4 +1,4 @@
 #pragma once
 #include "esp_http_server.h"
 
-esp_err_t status_get_handler(httpd_req_t *req);
+esp_err_t status_get_handler(httpd_req_t* req);

--- a/controlunit/components/rest_server/handlers/test/test_hello_handler.cpp
+++ b/controlunit/components/rest_server/handlers/test/test_hello_handler.cpp
@@ -1,15 +1,15 @@
 /**
  * @brief Test file for hello_handler.cpp
- * 
+ *
  * This is just an example test
- * 
+ *
  */
 extern "C" {
-    #include "unity.h"
+#include "unity.h"
 }
 #include "hello_handler.h"
 
 extern "C" void test_hello_handler_returns_ok(void) {
-    esp_err_t result = hello_get_handler(nullptr); 
+    esp_err_t result = hello_get_handler(nullptr);
     TEST_ASSERT_EQUAL(ESP_OK, result);
 }

--- a/controlunit/components/rest_server/rest_server.cpp
+++ b/controlunit/components/rest_server/rest_server.cpp
@@ -1,9 +1,9 @@
 #include "rest_server.h"
-#include "hello_handler.h"
-#include "status_handler.h"
-#include "postexample_handler.h"
 #include "esp_http_server.h"
 #include "esp_log.h"
+#include "hello_handler.h"
+#include "postexample_handler.h"
+#include "status_handler.h"
 
 static const char* TAG = "rest_server";
 
@@ -16,27 +16,17 @@ void start_rest_server() {
     if (httpd_start(&server, &config) == ESP_OK) {
 
         httpd_uri_t hello_uri = {
-            .uri      = "/hello",
-            .method   = HTTP_GET,
-            .handler  = hello_get_handler,
-            .user_ctx = NULL
-        };
+            .uri = "/hello", .method = HTTP_GET, .handler = hello_get_handler, .user_ctx = NULL};
         httpd_register_uri_handler(server, &hello_uri);
 
         httpd_uri_t status_uri = {
-            .uri      = "/status",
-            .method   = HTTP_GET,
-            .handler  = status_get_handler,
-            .user_ctx = NULL
-        };
+            .uri = "/status", .method = HTTP_GET, .handler = status_get_handler, .user_ctx = NULL};
         httpd_register_uri_handler(server, &status_uri);
 
-        httpd_uri_t postexample_uri = {
-            .uri      = "/postexample",
-            .method   = HTTP_POST,
-            .handler  = postexample_post_handler,
-            .user_ctx = NULL
-            };
+        httpd_uri_t postexample_uri = {.uri      = "/postexample",
+                                       .method   = HTTP_POST,
+                                       .handler  = postexample_post_handler,
+                                       .user_ctx = NULL};
         httpd_register_uri_handler(server, &postexample_uri);
 
         ESP_LOGI(TAG, "Server started");

--- a/controlunit/components/sensor_data/sensor_data_types.cpp
+++ b/controlunit/components/sensor_data/sensor_data_types.cpp
@@ -1,16 +1,17 @@
 #include "sensor_data_types.h"
 
+const std::string& Uuid::toString() const {
+    return value;
+}
 
-    const std::string& Uuid::toString() const { return value; }
+bool Uuid::isValid() const {
+    return !value.empty();
+}
 
-    bool Uuid::isValid() const {
-        return !value.empty();
-    }
+bool Uuid::operator==(const Uuid& other) const {
+    return value == other.value;
+}
 
-    bool Uuid::operator==(const Uuid& other) const {
-        return value == other.value;
-    }
-
-    bool Uuid::operator<(const Uuid& other) const {
-        return value < other.value;
-    }
+bool Uuid::operator<(const Uuid& other) const {
+    return value < other.value;
+}

--- a/controlunit/components/sensor_data/sensor_data_types.h
+++ b/controlunit/components/sensor_data/sensor_data_types.h
@@ -1,7 +1,7 @@
 #pragma once
-#include <string>
 #include <ctime>
 #include <memory>
+#include <string>
 
 struct Uuid {
     std::string value;
@@ -9,14 +9,14 @@ struct Uuid {
     Uuid() = default;
     explicit Uuid(const std::string& v) : value(v) {}
     const std::string& toString() const;
-    bool isValid() const;
-    bool operator==(const Uuid& other) const;
-    bool operator<(const Uuid& other) const;
+    bool               isValid() const;
+    bool               operator==(const Uuid& other) const;
+    bool               operator<(const Uuid& other) const;
 };
 
 struct ca_sensorunit_snapshot {
     std::shared_ptr<Uuid> uuid;
-    time_t timestamp;
-    double temperature;
-    double humidity;
+    time_t                timestamp;
+    double                temperature;
+    double                humidity;
 };

--- a/controlunit/components/sensor_unit_manager/SensorUnitManager.cpp
+++ b/controlunit/components/sensor_unit_manager/SensorUnitManager.cpp
@@ -3,8 +3,7 @@
 
 static const char* SENSORUM_TAG = "sensor_unit_manager";
 
-void SensorUnitManager::addUnit(const Uuid& uuid)
-{
+void SensorUnitManager::addUnit(const Uuid& uuid) {
     if (m_active_units.find(uuid) == m_active_units.end()) {
         m_active_units[uuid] = std::make_shared<Uuid>(uuid);
         ESP_LOGI(SENSORUM_TAG, "Adding Sensor Unit %s", uuid.toString().c_str());
@@ -13,8 +12,7 @@ void SensorUnitManager::addUnit(const Uuid& uuid)
     }
 }
 
-void SensorUnitManager::removeUnit(const Uuid& uuid)
-{
+void SensorUnitManager::removeUnit(const Uuid& uuid) {
     auto it = m_active_units.find(uuid);
     if (it != m_active_units.end()) {
         m_active_units.erase(it);
@@ -24,18 +22,16 @@ void SensorUnitManager::removeUnit(const Uuid& uuid)
     }
 }
 
-bool SensorUnitManager::hasUnit(const Uuid& uuid) const
-{
+bool SensorUnitManager::hasUnit(const Uuid& uuid) const {
     return (m_active_units.find(uuid) != m_active_units.end());
 }
 
-void SensorUnitManager::storeReading(const ca_sensorunit_snapshot& reading)
-{
+void SensorUnitManager::storeReading(const ca_sensorunit_snapshot& reading) {
     m_all_readings.push_back(reading);
 }
 
-std::map<time_t, std::vector<ca_sensorunit_snapshot>> SensorUnitManager::getGroupedReadings() const
-{
+std::map<time_t, std::vector<ca_sensorunit_snapshot>>
+SensorUnitManager::getGroupedReadings() const {
     std::map<time_t, std::vector<ca_sensorunit_snapshot>> grouped;
     for (const auto& snapshot : m_all_readings) {
         grouped[snapshot.timestamp].push_back(snapshot);
@@ -43,9 +39,6 @@ std::map<time_t, std::vector<ca_sensorunit_snapshot>> SensorUnitManager::getGrou
     return grouped;
 }
 
-void SensorUnitManager::clearReadings()
-{
+void SensorUnitManager::clearReadings() {
     m_all_readings.clear();
 }
-
-    

--- a/controlunit/components/sensor_unit_manager/SensorUnitManager.h
+++ b/controlunit/components/sensor_unit_manager/SensorUnitManager.h
@@ -1,20 +1,20 @@
 #pragma once
 #include "sensor_data_types.h"
+#include <map>
 #include <string>
 #include <vector>
-#include <map>
 
 class SensorUnitManager {
-public:
+  public:
     void addUnit(const Uuid& uuid);
     void removeUnit(const Uuid& uuid);
     bool hasUnit(const Uuid& uuid) const;
 
     void storeReading(const ca_sensorunit_snapshot& reading);
     std::map<time_t, std::vector<ca_sensorunit_snapshot>> getGroupedReadings() const;
-    void clearReadings();
+    void                                                  clearReadings();
 
-private:
+  private:
     std::map<Uuid, std::shared_ptr<Uuid>> m_active_units;
-    std::vector<ca_sensorunit_snapshot> m_all_readings;
+    std::vector<ca_sensorunit_snapshot>   m_all_readings;
 };

--- a/controlunit/components/sensor_unit_manager/test/test_SensorUnitManager.cpp
+++ b/controlunit/components/sensor_unit_manager/test/test_SensorUnitManager.cpp
@@ -1,23 +1,23 @@
 /**
  * @brief Test file for SensorUnitManager.cpp
- * 
- * 
+ *
+ *
  */
 extern "C" {
-    #include "unity.h"
+#include "unity.h"
 }
 #include "SensorUnitManager.h"
 
 extern "C" void when_manager_empty_then_hasUnit_returns_false(void) {
     SensorUnitManager manager;
-    Uuid uuid  {"abc"};
-    bool hasUnit = manager.hasUnit(uuid);
+    Uuid              uuid{"abc"};
+    bool              hasUnit = manager.hasUnit(uuid);
     TEST_ASSERT_EQUAL(hasUnit, false);
 }
 
 extern "C" void when_unit_added_then_hasUnit_returns_true(void) {
     SensorUnitManager manager;
-    Uuid uuid {"abc"};
+    Uuid              uuid{"abc"};
     manager.addUnit(uuid);
     bool hasUnit = manager.hasUnit(uuid);
     TEST_ASSERT_EQUAL(hasUnit, true);
@@ -25,7 +25,7 @@ extern "C" void when_unit_added_then_hasUnit_returns_true(void) {
 
 extern "C" void when_unit_added_and_removed_then_hasUnit_returns_false(void) {
     SensorUnitManager manager;
-    Uuid uuid {"abc"};
+    Uuid              uuid{"abc"};
     manager.addUnit(uuid);
     manager.removeUnit(uuid);
     bool hasUnit = manager.hasUnit(uuid);
@@ -34,16 +34,16 @@ extern "C" void when_unit_added_and_removed_then_hasUnit_returns_false(void) {
 
 extern "C" void when_unit_added_twice_then_logs_error(void) {
     SensorUnitManager manager;
-    Uuid uuid {"abc"};
+    Uuid              uuid{"abc"};
     manager.addUnit(uuid);
-    manager.addUnit(uuid); 
+    manager.addUnit(uuid);
     TEST_ASSERT_EQUAL(manager.hasUnit(uuid), true);
 }
 
 extern "C" void when_nonexistent_unit_removed_then_logs_error(void) {
     SensorUnitManager manager;
-    Uuid uuid {"xyz"};
-    manager.removeUnit(uuid); 
+    Uuid              uuid{"xyz"};
+    manager.removeUnit(uuid);
     TEST_ASSERT_EQUAL(manager.hasUnit(uuid), false);
 }
 
@@ -55,12 +55,14 @@ extern "C" void stress_test_many_units(void) {
     TEST_ASSERT_EQUAL(manager.hasUnit(Uuid{"500"}), true);
 }
 
-static ca_sensorunit_snapshot makeSnapshot(const std::string& uuid_str, time_t timestamp, double temp, double humidity) {
+static ca_sensorunit_snapshot
+makeSnapshot(const std::string& uuid_str, time_t timestamp, double temp, double humidity) {
     auto uuid_ptr = std::make_shared<Uuid>(Uuid{uuid_str});
     return ca_sensorunit_snapshot{uuid_ptr, timestamp, temp, humidity};
 }
 
-static void assertSnapshotEqual(const ca_sensorunit_snapshot& expected, const ca_sensorunit_snapshot& actual) {
+static void assertSnapshotEqual(const ca_sensorunit_snapshot& expected,
+                                const ca_sensorunit_snapshot& actual) {
     TEST_ASSERT_NOT_NULL(actual.uuid.get());
     TEST_ASSERT_EQUAL_STRING(expected.uuid->toString().c_str(), actual.uuid->toString().c_str());
     TEST_ASSERT_EQUAL(expected.timestamp, actual.timestamp);
@@ -68,16 +70,16 @@ static void assertSnapshotEqual(const ca_sensorunit_snapshot& expected, const ca
     TEST_ASSERT_EQUAL(expected.humidity, actual.humidity);
 }
 
-extern "C" void when_reading_stored_then_it_is_grouped_by_timestamp(void) { 
+extern "C" void when_reading_stored_then_it_is_grouped_by_timestamp(void) {
     SensorUnitManager manager;
-    manager.addUnit(Uuid{"abcde"});     
-    ca_sensorunit_snapshot snapshot = makeSnapshot("qwe", 1000, 25, 50);    
+    manager.addUnit(Uuid{"abcde"});
+    ca_sensorunit_snapshot snapshot = makeSnapshot("qwe", 1000, 25, 50);
     manager.storeReading(snapshot);
     auto grouped = manager.getGroupedReadings();
 
     TEST_ASSERT_NOT_EQUAL(grouped.end(), grouped.find(1000));
-    TEST_ASSERT_EQUAL(1, grouped.size());    
-    TEST_ASSERT_EQUAL(1, grouped[1000].size());    
+    TEST_ASSERT_EQUAL(1, grouped.size());
+    TEST_ASSERT_EQUAL(1, grouped[1000].size());
 
     assertSnapshotEqual(snapshot, grouped[1000].at(0));
 }

--- a/controlunit/helpers/filter_compile_commands.py
+++ b/controlunit/helpers/filter_compile_commands.py
@@ -1,0 +1,29 @@
+# filter out gcc flags for clang-tidy
+import os
+import json
+
+script_dir = os.path.dirname(os.path.abspath(__file__))
+project_root = os.path.abspath(os.path.join(script_dir, ".."))
+input_path = os.path.join(project_root, "build", "compile_commands.json")
+output_path = os.path.join(project_root, "build", "clang-tidy", "compile_commands.json")
+
+os.makedirs(os.path.dirname(output_path), exist_ok=True)
+
+with open(input_path) as f:
+    commands = json.load(f)
+
+filtered = []
+for entry in commands:
+    if "components" not in entry["file"] and "main" not in entry["file"]:
+        continue
+
+    args = entry.get("arguments") or entry["command"].split()
+    args = [arg for arg in args if arg not in [
+        "-mlongcalls", "-fno-shrink-wrap", "-fno-tree-switch-conversion", "-fstrict-volatile-bitfields"
+    ]]
+
+    entry["arguments"] = args
+    filtered.append(entry)
+
+with open(output_path, "w") as f:
+    json.dump(filtered, f, indent=2)

--- a/controlunit/main/main.cpp
+++ b/controlunit/main/main.cpp
@@ -1,20 +1,16 @@
+#include "hello_handler.h"
+#include "rest_server.h"
 #include "wifi_config.h"
 #include "wifi_manager.h"
-#include "rest_server.h"
-#include "hello_handler.h"
+#include <esp_event.h>
 #include <esp_http_server.h>
 #include <esp_log.h>
-#include <esp_wifi.h>
-#include <esp_event.h>
 #include <esp_netif.h>
+#include <esp_wifi.h>
 #include <nvs_flash.h>
-
-
-
 
 extern "C" void app_main(void) {
     nvs_flash_init();
     init_wifi();
     start_rest_server();
-
 }

--- a/controlunit/test_runner/main/main.cpp
+++ b/controlunit/test_runner/main/main.cpp
@@ -1,16 +1,16 @@
 /**
  * @brief main file for the test_runner
- * 
+ *
  * This is for running unit tests. It is still just an example
  * For now it runs them on the hardware
  * Will be separated into native logic tests and also Dockerized later on
- * 
+ *
  */
 extern "C" {
-    #include <unity.h>
-    #include <freertos/FreeRTOS.h>
-    #include <freertos/task.h>
-    #include <esp_log.h>
+#include <esp_log.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+#include <unity.h>
 }
 
 // Deklarera testfunktionen från komponenten
@@ -38,7 +38,7 @@ extern "C" void app_main() {
     ESP_LOGI("TEST", "Testing SensorUnitManager");
     UNITY_BEGIN();
     RUN_TEST(when_manager_empty_then_hasUnit_returns_false);
-    RUN_TEST(when_unit_added_then_hasUnit_returns_true);     
+    RUN_TEST(when_unit_added_then_hasUnit_returns_true);
     RUN_TEST(when_unit_added_and_removed_then_hasUnit_returns_false);
     RUN_TEST(when_unit_added_twice_then_logs_error);
     RUN_TEST(when_nonexistent_unit_removed_then_logs_error);
@@ -48,4 +48,4 @@ extern "C" void app_main() {
     RUN_TEST(when_storing_readings_with_different_timestamps_then_grouped_separately);
     RUN_TEST(after_clearing_readings_grouped_readings_is_empty);
     UNITY_END();
-    }
+}

--- a/sensorunit/.clang-format
+++ b/sensorunit/.clang-format
@@ -1,0 +1,43 @@
+BasedOnStyle: LLVM
+Language: Cpp
+Standard: Latest
+
+IndentWidth: 4
+TabWidth: 4
+UseTab: Never
+
+ColumnLimit: 100
+AllowShortFunctionsOnASingleLine: Inline
+BreakBeforeBraces: Attach
+BraceWrapping:
+  AfterFunction: false
+  AfterControlStatement: false
+  AfterEnum: false
+  AfterStruct: false
+
+SortIncludes: true
+IncludeBlocks: Preserve
+IncludeCategories:
+  - Regex: '^".*\.h"'
+    Priority: 1
+  - Regex: '^<.*\.h>'
+    Priority: 2
+  - Regex: '.*'
+    Priority: 3
+
+PointerAlignment: Left
+ReferenceAlignment: Left
+
+SpacesBeforeTrailingComments: 1
+SpaceBeforeParens: ControlStatements
+SpaceAfterCStyleCast: true
+
+AlignConsecutiveAssignments: true
+AlignConsecutiveDeclarations: true
+AlignOperands: true
+AlignTrailingComments: true
+
+Cpp11BracedListStyle: true
+AllowAllParametersOfDeclarationOnNextLine: false
+BinPackParameters: false
+BinPackArguments: false

--- a/sensorunit/.clang-tidy
+++ b/sensorunit/.clang-tidy
@@ -1,0 +1,45 @@
+Checks: >
+  clang-analyzer-*,
+  bugprone-*,
+  performance-*,
+  readability-*,
+  cppcoreguidelines-*,
+  modernize-*,
+  misc-*,
+  -fuchsia-*,
+  -google-*,
+  -hicpp-*,
+  -llvm-header-guard,
+  -modernize-use-default-member-init,
+  -modernize-use-trailing-return-type,
+  -modernize-use-auto,
+  -cppcoreguidelines-no-malloc,
+  -cppcoreguidelines-owning-memory
+
+CheckOptions:
+  - key: modernize-use-auto.MinTypeNameLength
+    value: '15'
+  - key: readability-identifier-naming.FunctionCase
+    value: camelCase
+  - key: readability-identifier-naming.VariableCase
+    value: camelBack
+  - key: readability-identifier-naming.ConstantPrefix
+    value: k
+  - key: readability-identifier-naming.MemberPrefix
+    value: m_
+  - key: readability-identifier-naming.ClassCase
+    value: CamelCase
+  - key: readability-identifier-naming.StructCase
+    value: CamelCase
+  - key: readability-identifier-naming.EnumCase
+    value: CamelCase
+  - key: readability-identifier-naming.EnumConstantCase
+    value: CamelCase
+  - key: readability-identifier-naming.NamespaceCase
+    value: lower_case
+  - key: readability-identifier-naming.GlobalConstantPrefix
+    value: k
+  - key: readability-identifier-naming.GlobalConstantCase
+    value: CamelCase
+  - key: cppcoreguidelines-pro-type-vararg.IgnoreMacros
+    value: 'UNITY_BEGIN,UNITY_END,RUN_TEST,TEST_ASSERT_EQUAL'

--- a/sensorunit/.gitignore
+++ b/sensorunit/.gitignore
@@ -7,3 +7,6 @@
 # Ignore sensitive files
 arduino_secrets.h
 .env
+
+# Ignore local file generated when building
+compile_commands.json

--- a/sensorunit/helpers/compiledb.py
+++ b/sensorunit/helpers/compiledb.py
@@ -1,2 +1,3 @@
+# type: ignore
 Import("env")
 env.AddPostAction("buildprog", "platformio run --target compiledb")

--- a/sensorunit/helpers/compiledb.py
+++ b/sensorunit/helpers/compiledb.py
@@ -1,0 +1,2 @@
+Import("env")
+env.AddPostAction("buildprog", "platformio run --target compiledb")

--- a/sensorunit/platformio.ini
+++ b/sensorunit/platformio.ini
@@ -14,3 +14,4 @@ board = uno_r4_wifi
 framework = arduino
 monitor_speed = 115200
 lib_extra_dirs = ../dependencies
+build_flags = -DCOMPILE_COMMANDS

--- a/sensorunit/platformio.ini
+++ b/sensorunit/platformio.ini
@@ -14,4 +14,4 @@ board = uno_r4_wifi
 framework = arduino
 monitor_speed = 115200
 lib_extra_dirs = ../dependencies
-build_flags = -DCOMPILE_COMMANDS
+extra_scripts = helpers/compiledb.py

--- a/sensorunit/src/main.cpp
+++ b/sensorunit/src/main.cpp
@@ -2,12 +2,10 @@
 #include <etl/string.h>
 #include <etl/vector.h>
 
+int             counter{0};
+etl::string<32> hello{};
 
-int counter {0};
-etl::string<32> hello {};
-
-void setup()
-{
+void setup() {
     hello.append("Hello ETL Arduino No ");
 
     Serial.begin(115200);
@@ -18,8 +16,7 @@ void setup()
     counter++;
 }
 
-void loop()
-{
+void loop() {
     delay(2000);
     Serial.print(hello.c_str());
     Serial.println(counter);


### PR DESCRIPTION
.clang-format added in both controlunit/ and sensorunit/ for code style checks based on LLVM style
.clang-tidy also added for static code analysis but conflicting with gcc so not a working solution
No precommit added yet. It has to wait until an alternative is in place.
