### PR TITLE
chore: update clangtidy with namespace_constants and TEST_MACROS

### DIFF
--- a/controlunit/.clang-tidy
+++ b/controlunit/.clang-tidy
@@ -45,7 +45,25 @@ CheckOptions:
     value: k
   - key: readability-identifier-naming.GlobalConstantCase
     value: CamelCase
+  - key: readability-identifier-naming.NamespaceConstantCase
+    value: lower_case
+  - key: readability-identifier-naming.NamespaceConstantPrefix
+    value: ''
   - key: cppcoreguidelines-pro-type-vararg.IgnoreMacros
-    value: 'ESP_LOGI,ESP_LOGE,ESP_LOGW,ESP_LOGD,UNITY_BEGIN,UNITY_END,RUN_TEST,TEST_ASSERT_EQUAL'
+    value: > 
+      ESP_LOGI,
+      ESP_LOGE,
+      ESP_LOGW,
+      ESP_LOGD,
+      UNITY_BEGIN,
+      UNITY_END,
+      RUN_TEST,
+      TEST_ASSERT_EQUAL,
+      TEST_ASSERT_EQUAL_STRING,
+      TEST_ASSERT_EQUAL_UINT32,
+      TEST_ASSERT_NOT_EQUAL,
+      TEST_ASSERT_FLOAT_WITHIN,
+      TEST_ASSERT_NULL,
+      TEST_ASSERT_NOT_NULL
   - key: misc-definitions-in-headers.IgnoreMacros
     value: 'ESP_EVENT_HANDLER_INSTANCE_DECLARE'

--- a/sensorunit/.clang-tidy
+++ b/sensorunit/.clang-tidy
@@ -41,5 +41,16 @@ CheckOptions:
     value: k
   - key: readability-identifier-naming.GlobalConstantCase
     value: CamelCase
+  - key: readability-identifier-naming.NamespaceConstantCase
+    value: lower_case
+  - key: readability-identifier-naming.NamespaceConstantPrefix
+    value: ''
   - key: cppcoreguidelines-pro-type-vararg.IgnoreMacros
-    value: 'UNITY_BEGIN,UNITY_END,RUN_TEST,TEST_ASSERT_EQUAL'
+    value: > 
+      UNITY_BEGIN,
+      UNITY_END,
+      RUN_TEST,
+      TEST_ASSERT_EQUAL,
+      TEST_ASSERT_EQUAL_STRING,
+      TEST_ASSERT_FLOAT_WITHIN,
+      TEST_ASSERT_TRUE


### PR DESCRIPTION
Small update to clang-tidy in both sensorunit and controlunit