### PR TITLE
refactor: compose JSON payload in JsonParser instead of TimeHandler

### DIFF
--- a/controlunit/components/json_parser/JsonParser.h
+++ b/controlunit/components/json_parser/JsonParser.h
@@ -3,12 +3,11 @@
  * @brief Static utility class for parsing and composing JSON related to sensor
  * and connection data.
  *
- * Provides functions for converting to and from internal data structures and JSON
- * strings 
- * From Sensor Unit: connect requests/responses, batched sensor readings, 
- * From Backend: connect requests
- * To Backend: batched sensor readings, connect responses, error messages
- * 
+ * Provides functions for converting to and from internal data structures and
+ * JSON strings From Sensor Unit: connect requests/responses, batched sensor
+ * readings, From Backend: connect requests To Backend: batched sensor readings,
+ * connect responses, error messages
+ *
  * All methods are static and stateless, defined in the JsonParser class.
  *
  * @author Erik Dahl (erik@iunderlandet.se)
@@ -89,6 +88,16 @@ class JsonParser {
      */
     static std::string
     composeSensorunitStatusPayload(const std::string& status);
+
+    /**
+     * @brief Composes a JSON payload containing a Unix timestamp.
+     *
+     * Example: {"timestamp": <Unixtimestamp> }
+     *
+     * @param now The current time as a Unix timestamp (time_t).
+     * @return A JSON-formatted string containing the timestamp.
+     */
+    static std::string composeTimestampPayload(time_t now);
 
     /**
      * @brief Composes a generic error response in JSON format. (Unused)

--- a/controlunit/components/rest_server/handlers/TimeHandler.cpp
+++ b/controlunit/components/rest_server/handlers/TimeHandler.cpp
@@ -1,20 +1,17 @@
 /**
- * @file HelloHandler.cpp
- * @brief Implementation of HelloHandler, a simple GET endpoint that returns a
- * greeting.
+ * @file TimeHandler.cpp
+ * @brief Implementation of GET /time endpoint
  *
- * Defines the logic for responding to HTTP GET requests with a static greeting
- * message. Inherits from GetHandler and overrides the `process()` method to
- * send a plain-text response.
- *
- * Useful for testing server availability or providing a basic health check.
+ * Has a reference to TimeSyncManager. If time is synced it sends
+ * a Unix Timestamp in JSON with key "timestamp"
  *
  * @author Erik Dahl (erik@iunderlandet.se)
- * @date 2025-10-07
+ * @date 2025-10-16
  * @copyright Copyright (c) 2025 Erik Dahl
  * @license MIT
  */
 #include "TimeHandler.h"
+#include "JsonParser.h"
 #include "esp_log.h"
 #include "time.h"
 
@@ -32,12 +29,10 @@ esp_err_t TimeHandler::process(httpd_req_t* req) {
     time_t now;
     time(&now);
     ESP_LOGI(TAG,"Control Unit timestamp: %lld", static_cast<long long>(now));    
-
-    char response[64];
-    uint32_t truncatedTimestamp = static_cast<uint32_t>(now);
-    snprintf(response, sizeof(response), "{\"timestamp\": %lu}", truncatedTimestamp);
+    
+    std::string payload = JsonParser::composeTimestampPayload(now);
     httpd_resp_set_type(req, "application/json");
-    httpd_resp_send(req, response, HTTPD_RESP_USE_STRLEN);
-    ESP_LOGI(TAG, "Sending Control Unit timestamp as uint32_t: %lu", truncatedTimestamp);
+    httpd_resp_send(req, payload.c_str(), HTTPD_RESP_USE_STRLEN);
+    ESP_LOGI(TAG, "Sending Control Unit timestamp as double: %.0f", static_cast<double>(now));
     return ESP_OK;
 }


### PR DESCRIPTION
Move Json parsing for /time endpoint to JsonParser for consistency with other handlers (instead of C-style parsing inside the TimeHandler itself)